### PR TITLE
Support for DRV8835 driver in phase/enable mode.

### DIFF
--- a/src/ic.rs
+++ b/src/ic.rs
@@ -19,3 +19,15 @@ pub struct TB6612FNG;
 ///
 /// (IN1, IN2, PWM) = (In1, In2, EnA) OR (In3, In4, EnB)
 pub struct L298;
+
+/// TI's DRV8835 dual DC motor driver in phase/enable mode
+///
+/// # Connections
+///
+/// - PHASE to xPHASE/xIN1
+/// - ENABLE to xENABLE/xIN2
+///
+/// where x = A or B
+///
+/// MODE pin needs to be driven high for phase/enable control mode
+pub struct DRV8835PE;


### PR DESCRIPTION
This driver IC uses either two PWM control inputs (in/in mode) or a digital input to control direction and a PWM input to control speed (phase/enable mode).

The PR adds support for phase/enable mode only.

More information: https://www.pololu.com/product/2135